### PR TITLE
 Add getshielddatalength API

### DIFF
--- a/app.js
+++ b/app.js
@@ -112,7 +112,7 @@ app.get("/mainnet/getshielddatalength", async (req, res) => {
     ({ block }) => block >= startBlock,
   )?.i;
   const endingByte = shield["mainnet"].find(
-    ({ block }, i) => block >= endBlock),
+    ({ block }, i) => block >= endBlock,
 )?.i;
 
   if (startingByte === undefined) {

--- a/app.js
+++ b/app.js
@@ -111,8 +111,8 @@ app.get("/mainnet/getshielddatalength", async (req, res) => {
   const startingByte = shield["mainnet"].find(
     ({ block }) => block >= startBlock,
   )?.i;
-  const endingByte = shield["mainnet"].findLast(
-    ({ block }) => block <= endBlock,
+  const endingByte = shield["mainnet"].find(
+    ({ block }) => block >= endBlock,
   )?.i;
   if (startingByte === undefined) {
     res.status(422).send("startBlock is not a valid starting block");

--- a/app.js
+++ b/app.js
@@ -112,13 +112,20 @@ app.get("/mainnet/getshielddatalength", async (req, res) => {
     ({ block }) => block >= startBlock,
   )?.i;
   const endingByte = shield["mainnet"].find(
-    ({ block }) => block >= endBlock,
-  )?.i;
+    ({ block }, i) => block >= endBlock),
+)?.i;
+
   if (startingByte === undefined) {
     res.status(422).send("startBlock is not a valid starting block");
     return;
   }
-  res.status(200).send((endingByte - startingByte).toString());
+    if (endingByte === undefined) {
+	// If there is no ending byte, the length is the length of the file - startingByte
+	// FIXME: This is not very efficient...
+	res.statuts(200).send((await getShieldBinary(false, startingByte)).length.toString());
+	return;
+    }
+    res.status(200).send((endingByte - startingByte).toString());
 });
 
 app.get("/mainnet/:rpc", async (req, res) => handleRequest(false, req, res));

--- a/app.js
+++ b/app.js
@@ -122,7 +122,7 @@ app.get("/mainnet/getshielddatalength", async (req, res) => {
     if (endingByte === undefined) {
 	// If there is no ending byte, the length is the length of the file - startingByte
 	// FIXME: This is not very efficient...
-	res.statuts(200).send((await getShieldBinary(false, startingByte)).length.toString());
+	res.status(200).send((await getShieldBinary(false, startingByte)).length.toString());
 	return;
     }
     res.status(200).send((endingByte - startingByte).toString());

--- a/app.js
+++ b/app.js
@@ -112,7 +112,7 @@ app.get("/mainnet/getshielddatalength", async (req, res) => {
     ({ block }) => block >= startBlock,
   )?.i;
   const endingByte = shield["mainnet"].findLast(
-    ({ block }) => block <= endingBlock,
+    ({ block }) => block <= endBlock,
   )?.i;
   if (startingByte === undefined) {
     res.status(422).send("startBlock is not a valid starting block");

--- a/app.js
+++ b/app.js
@@ -91,7 +91,6 @@ app.get("/mainnet/getshielddata", async (req, res) => {
   const startingByte = shield["mainnet"]
     // Get the first block that's greater or equal than the requested starting block
     .find(({ block }) => block >= startBlock)?.i;
-  console.log(startingByte);
   if (startingByte === undefined) {
     const noContent = 204;
     res.status(noContent).send(Buffer.from([]));
@@ -100,6 +99,26 @@ app.get("/mainnet/getshielddata", async (req, res) => {
   const shieldBinary = await getShieldBinary(false, startingByte);
   res.set("X-Content-Length", shieldBinary.length);
   res.send(shieldBinary);
+});
+
+app.get("/mainnet/getshielddatalength", async (req, res) => {
+  const startBlock = req.query.startBlock || 0;
+  const endBlock = req.query.endBlock || Number.POSITIVE_INFINITY;
+  if (startBlock > endBlock) {
+    res.status(422).send("startBlock must be less or equal than endBlock");
+    return;
+  }
+  const startingByte = shield["mainnet"].find(
+    ({ block }) => block >= startBlock,
+  )?.i;
+  const endingByte = shield["mainnet"].findLast(
+    ({ block }) => block <= endingBlock,
+  )?.i;
+  if (startingByte === undefined) {
+    res.status(422).send("startBlock is not a valid starting block");
+    return;
+  }
+  res.status(200).send(endingByte - startingByte);
 });
 
 app.get("/mainnet/:rpc", async (req, res) => handleRequest(false, req, res));

--- a/app.js
+++ b/app.js
@@ -118,7 +118,7 @@ app.get("/mainnet/getshielddatalength", async (req, res) => {
     res.status(422).send("startBlock is not a valid starting block");
     return;
   }
-  res.status(200).send(endingByte - startingByte);
+  res.status(200).send((endingByte - startingByte).toString());
 });
 
 app.get("/mainnet/:rpc", async (req, res) => handleRequest(false, req, res));

--- a/app.js
+++ b/app.js
@@ -113,19 +113,21 @@ app.get("/mainnet/getshielddatalength", async (req, res) => {
   )?.i;
   const endingByte = shield["mainnet"].find(
     ({ block }, i) => block >= endBlock,
-)?.i;
+  )?.i;
 
   if (startingByte === undefined) {
     res.status(422).send("startBlock is not a valid starting block");
     return;
   }
-    if (endingByte === undefined) {
-	// If there is no ending byte, the length is the length of the file - startingByte
-	// FIXME: This is not very efficient...
-	res.status(200).send((await getShieldBinary(false, startingByte)).length.toString());
-	return;
-    }
-    res.status(200).send((endingByte - startingByte).toString());
+  if (endingByte === undefined) {
+    // If there is no ending byte, the length is the length of the file - startingByte
+    // FIXME: This is not very efficient...
+    res
+      .status(200)
+      .send((await getShieldBinary(false, startingByte)).length.toString());
+    return;
+  }
+  res.status(200).send((endingByte - startingByte).toString());
 });
 
 app.get("/mainnet/:rpc", async (req, res) => handleRequest(false, req, res));


### PR DESCRIPTION
This API takes two params: A starting block and an ending block, it then returns the length in bytes of all the block between those two.
This is needed to ease the caching of the shield data, without the need for the client to store the byte position of all the blocks